### PR TITLE
Matrix ExtractScale() bug fix and "Clear" methods

### DIFF
--- a/Source/OpenTK/Math/Matrix3.cs
+++ b/Source/OpenTK/Math/Matrix3.cs
@@ -288,6 +288,29 @@ namespace OpenTK
         }
 
         /// <summary>
+        /// Returns a copy of this Matrix3 without scale.
+        /// </summary>
+        public Matrix3 ClearScale()
+        {
+            Matrix3 m = this;
+            m.Row0 = m.Row0.Normalized();
+            m.Row1 = m.Row1.Normalized();
+            m.Row2 = m.Row2.Normalized();
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix3 without rotation.
+        /// </summary>
+        public Matrix3 ClearRotation()
+        {
+            Matrix3 m = this;
+            m.Row0 = new Vector3(m.Row0.Length, 0, 0);
+            m.Row1 = new Vector3(0, m.Row1.Length, 0);
+            m.Row2 = new Vector3(0, 0, m.Row2.Length);
+            return m;
+        }
+
+        /// <summary>
         /// Returns the scale component of this instance.
         /// </summary>
         public Vector3 ExtractScale() { return new Vector3(Row0.Length, Row1.Length, Row2.Length); }

--- a/Source/OpenTK/Math/Matrix3d.cs
+++ b/Source/OpenTK/Math/Matrix3d.cs
@@ -283,6 +283,30 @@ namespace OpenTK
             return m;
         }
 
+
+        /// <summary>
+        /// Returns a copy of this Matrix3 without scale.
+        /// </summary>
+        public Matrix3d ClearScale()
+        {
+            Matrix3d m = this;
+            m.Row0 = m.Row0.Normalized();
+            m.Row1 = m.Row1.Normalized();
+            m.Row2 = m.Row2.Normalized();
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix3 without rotation.
+        /// </summary>
+        public Matrix3d ClearRotation()
+        {
+            Matrix3d m = this;
+            m.Row0 = new Vector3d(m.Row0.Length, 0, 0);
+            m.Row1 = new Vector3d(0, m.Row1.Length, 0);
+            m.Row2 = new Vector3d(0, 0, m.Row2.Length);
+            return m;
+        }
+
         /// <summary>
         /// Returns the scale component of this instance.
         /// </summary>

--- a/Source/OpenTK/Math/Matrix4.cs
+++ b/Source/OpenTK/Math/Matrix4.cs
@@ -350,6 +350,47 @@ namespace OpenTK
         }
 
         /// <summary>
+        /// Returns a copy of this Matrix4 without translation.
+        /// </summary>
+        public Matrix4 ClearTranslation()
+        {
+            Matrix4 m = this;
+            m.Row3.Xyz = Vector3.Zero;
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4 without scale.
+        /// </summary>
+        public Matrix4 ClearScale()
+        {
+            Matrix4 m = this;
+            m.Row0.Xyz = m.Row0.Xyz.Normalized();
+            m.Row1.Xyz = m.Row1.Xyz.Normalized();
+            m.Row2.Xyz = m.Row2.Xyz.Normalized();
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4 without rotation.
+        /// </summary>
+        public Matrix4 ClearRotation()
+        {
+            Matrix4 m = this;
+            m.Row0.Xyz = new Vector3(m.Row0.Xyz.Length, 0, 0);
+            m.Row1.Xyz = new Vector3(0, m.Row1.Xyz.Length, 0);
+            m.Row2.Xyz = new Vector3(0, 0, m.Row2.Xyz.Length);
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4 without projection.
+        /// </summary>
+        public Matrix4 ClearProjection()
+        {
+            Matrix4 m = this;
+            m.Column3 = Vector4.Zero;
+            return m;
+        }
+
+        /// <summary>
         /// Returns the translation component of this instance.
         /// </summary>
         public Vector3 ExtractTranslation() { return Row3.Xyz; }
@@ -357,7 +398,7 @@ namespace OpenTK
         /// <summary>
         /// Returns the scale component of this instance.
         /// </summary>
-        public Vector3 ExtractScale() { return new Vector3(Row0.Length, Row1.Length, Row2.Length); }
+        public Vector3 ExtractScale() { return new Vector3(Row0.Xyz.Length, Row1.Xyz.Length, Row2.Xyz.Length); }
 
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
@@ -424,6 +465,14 @@ namespace OpenTK
 
             q.Normalize();
             return q;
+        }
+
+        /// <summary>
+        /// Returns the projection component of this instance.
+        /// </summary>
+        public Vector4 ExtractProjection()
+        {
+            return Column3;
         }
 
         #endregion

--- a/Source/OpenTK/Math/Matrix4d.cs
+++ b/Source/OpenTK/Math/Matrix4d.cs
@@ -138,6 +138,7 @@ namespace OpenTK
         public Vector4d  Column0
         {
             get { return new Vector4d (Row0.X, Row1.X, Row2.X, Row3.X); }
+            set { Row0.X = value.X; Row1.X = value.Y; Row2.X = value.Z; Row3.X = value.W; }
         }
 
         /// <summary>
@@ -146,6 +147,7 @@ namespace OpenTK
         public Vector4d  Column1
         {
             get { return new Vector4d (Row0.Y, Row1.Y, Row2.Y, Row3.Y); }
+            set { Row0.Y = value.X; Row1.Y = value.Y; Row2.Y = value.Z; Row3.Y = value.W; }
         }
 
         /// <summary>
@@ -154,6 +156,7 @@ namespace OpenTK
         public Vector4d  Column2
         {
             get { return new Vector4d (Row0.Z, Row1.Z, Row2.Z, Row3.Z); }
+            set { Row0.Z = value.X; Row1.Z = value.Y; Row2.Z = value.Z; Row3.Z = value.W; }
         }
 
         /// <summary>
@@ -162,6 +165,7 @@ namespace OpenTK
         public Vector4d  Column3
         {
             get { return new Vector4d (Row0.W, Row1.W, Row2.W, Row3.W); }
+            set { Row0.W = value.X; Row1.W = value.Y; Row2.W = value.Z; Row3.W = value.W; }
         }
 
         /// <summary>
@@ -333,6 +337,47 @@ namespace OpenTK
         }
 
         /// <summary>
+        /// Returns a copy of this Matrix4d without translation.
+        /// </summary>
+        public Matrix4d ClearTranslation()
+        {
+            Matrix4d m = this;
+            m.Row3.Xyz = Vector3d.Zero;
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4d without scale.
+        /// </summary>
+        public Matrix4d ClearScale()
+        {
+            Matrix4d m = this;
+            m.Row0.Xyz = m.Row0.Xyz.Normalized();
+            m.Row1.Xyz = m.Row1.Xyz.Normalized();
+            m.Row2.Xyz = m.Row2.Xyz.Normalized();
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4d without rotation.
+        /// </summary>
+        public Matrix4d ClearRotation()
+        {
+            Matrix4d m = this;
+            m.Row0.Xyz = new Vector3d(m.Row0.Xyz.Length, 0, 0);
+            m.Row1.Xyz = new Vector3d(0, m.Row1.Xyz.Length, 0);
+            m.Row2.Xyz = new Vector3d(0, 0, m.Row2.Xyz.Length);
+            return m;
+        }
+        /// <summary>
+        /// Returns a copy of this Matrix4d without projection.
+        /// </summary>
+        public Matrix4d ClearProjection()
+        {
+            Matrix4d m = this;
+            m.Column3 = Vector4d.Zero;
+            return m;
+        }
+
+        /// <summary>
         /// Returns the translation component of this instance.
         /// </summary>
         public Vector3d ExtractTranslation() { return Row3.Xyz; }
@@ -340,7 +385,7 @@ namespace OpenTK
         /// <summary>
         /// Returns the scale component of this instance.
         /// </summary>
-        public Vector3d ExtractScale() { return new Vector3d(Row0.Length, Row1.Length, Row2.Length); }
+        public Vector3d ExtractScale() { return new Vector3d(Row0.Xyz.Length, Row1.Xyz.Length, Row2.Xyz.Length); }
 
         /// <summary>
         /// Returns the rotation component of this instance. Quite slow.
@@ -408,6 +453,15 @@ namespace OpenTK
             q.Normalize();
             return q;
         }
+
+        /// <summary>
+        /// Returns the projection component of this instance.
+        /// </summary>
+        public Vector4d ExtractProjection()
+        {
+            return Column3;
+        }
+
 
         #endregion
 


### PR DESCRIPTION
- Added ClearTranslation(), ClearScale(), ClearRotation() and
  ClearProjection()
- Added ExtractProjection() to Matrix4
- Fixed ExtractScale() giving incorrect results if a Matrix4 contained
  projection data
- Added setters to Matrix4d's Column properties
