### PR TITLE
Implemented Quaternion.FromMatrix

### DIFF
--- a/Source/OpenTK/Math/Matrix2.cs
+++ b/Source/OpenTK/Math/Matrix2.cs
@@ -142,6 +142,27 @@ namespace OpenTK
         /// </summary>
         public float M22 { get { return Row1.Y; } set { Row1.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2 Diagonal
+        {
+            get
+            {
+                return new Vector2(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix2d.cs
+++ b/Source/OpenTK/Math/Matrix2d.cs
@@ -142,6 +142,27 @@ namespace OpenTK
         /// </summary>
         public double M22 { get { return Row1.Y; } set { Row1.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2d Diagonal
+        {
+            get
+            {
+                return new Vector2d(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix2x3.cs
+++ b/Source/OpenTK/Math/Matrix2x3.cs
@@ -144,6 +144,27 @@ namespace OpenTK
         /// </summary>
         public float M23 { get { return Row1.Z; } set { Row1.Z = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2 Diagonal
+        {
+            get
+            {
+                return new Vector2(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix2x3d.cs
+++ b/Source/OpenTK/Math/Matrix2x3d.cs
@@ -144,6 +144,27 @@ namespace OpenTK
         /// </summary>
         public double M23 { get { return Row1.Z; } set { Row1.Z = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2d Diagonal
+        {
+            get
+            {
+                return new Vector2d(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix2x4.cs
+++ b/Source/OpenTK/Math/Matrix2x4.cs
@@ -165,6 +165,27 @@ namespace OpenTK
         /// </summary>
         public float M24 { get { return Row1.W; } set { Row1.W = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2 Diagonal
+        {
+            get
+            {
+                return new Vector2(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix2x4d.cs
+++ b/Source/OpenTK/Math/Matrix2x4d.cs
@@ -165,6 +165,27 @@ namespace OpenTK
         /// </summary>
         public double M24 { get { return Row1.W; } set { Row1.W = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2d Diagonal
+        {
+            get
+            {
+                return new Vector2d(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix3.cs
+++ b/Source/OpenTK/Math/Matrix3.cs
@@ -201,6 +201,28 @@ namespace OpenTK
         /// Gets or sets the value at row 3, column 3 of this instance.
         /// </summary>
         public float M33 { get { return Row2.Z; } set { Row2.Z = value; } }
+
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3 Diagonal
+        {
+            get
+            {
+                return new Vector3(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
         
         #endregion
 

--- a/Source/OpenTK/Math/Matrix3d.cs
+++ b/Source/OpenTK/Math/Matrix3d.cs
@@ -197,7 +197,29 @@ namespace OpenTK
         /// Gets or sets the value at row 3, column 3 of this instance.
         /// </summary>
         public double M33 { get { return Row2.Z; } set { Row2.Z = value; } }
-        
+
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3d Diagonal
+        {
+            get
+            {
+                return new Vector3d(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix3x2.cs
+++ b/Source/OpenTK/Math/Matrix3x2.cs
@@ -144,6 +144,27 @@ namespace OpenTK
         /// </summary>
         public float M32 { get { return Row2.Y; } set { Row2.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2 Diagonal
+        {
+            get
+            {
+                return new Vector2(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix3x2d.cs
+++ b/Source/OpenTK/Math/Matrix3x2d.cs
@@ -144,6 +144,27 @@ namespace OpenTK
         /// </summary>
         public double M32 { get { return Row2.Y; } set { Row2.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2d Diagonal
+        {
+            get
+            {
+                return new Vector2d(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix3x4.cs
+++ b/Source/OpenTK/Math/Matrix3x4.cs
@@ -196,6 +196,28 @@ namespace OpenTK
         /// </summary>
         public float M34 { get { return Row2.W; } set { Row2.W = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3 Diagonal
+        {
+            get
+            {
+                return new Vector3(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
+
         #endregion
 
         #region Indexers
@@ -227,6 +249,9 @@ namespace OpenTK
 
         #region public void Invert()
 
+        /// <summary>
+        /// Converts this instance into its inverse.
+        /// </summary>
         public void Invert()
         {
             this = Matrix3x4.Invert(this);
@@ -620,6 +645,12 @@ namespace OpenTK
             result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix3x4 Mult(Matrix3x4 left, Matrix3x4 right)
         {
             Matrix3x4 result;
@@ -627,6 +658,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
         {
             float lM11 = left.Row0.X, lM12 = left.Row0.Y, lM13 = left.Row0.Z, lM14 = left.Row0.W,
@@ -659,6 +696,12 @@ namespace OpenTK
             result.Row2.W += lM34;*/
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix3x4 Mult(Matrix3x4 left, float right)
         {
             Matrix3x4 result;
@@ -666,6 +709,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix3x4 left, float right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 * right;
@@ -677,6 +726,12 @@ namespace OpenTK
 
         #region Add Functions
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
         public static Matrix3x4 Add(Matrix3x4 left, Matrix3x4 right)
         {
             Matrix3x4 result;
@@ -684,6 +739,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
         public static void Add(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 + right.Row0;
@@ -695,6 +756,12 @@ namespace OpenTK
 
         #region Subtract Functions
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
         public static Matrix3x4 Subtract(Matrix3x4 left, Matrix3x4 right)
         {
             Matrix3x4 result;
@@ -702,6 +769,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
         public static void Subtract(ref Matrix3x4 left, ref Matrix3x4 right, out Matrix3x4 result)
         {
             result.Row0 = left.Row0 - right.Row0;
@@ -713,6 +786,12 @@ namespace OpenTK
 
         #region Invert Functions
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static Matrix3x4 Invert(Matrix3x4 mat)
         {
             Matrix3x4 result;
@@ -720,6 +799,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(ref Matrix3x4 mat, out Matrix3x4 result)
         {
             Matrix3 inverseRotation = new Matrix3(mat.Column0, mat.Column1, mat.Column2);
@@ -738,11 +823,21 @@ namespace OpenTK
 
         #region Transpose
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <returns>The transpose of the given matrix</returns>
         public static Matrix4x3 Transpose(Matrix3x4 mat)
         {
             return new Matrix4x3(mat.Column0, mat.Column1, mat.Column2, mat.Column3);
         }
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <param name="result">The result of the calculation</param>
         public static void Transpose(ref Matrix3x4 mat, out Matrix4x3 result)
         {
             result.Row0 = mat.Column0;
@@ -757,36 +852,78 @@ namespace OpenTK
 
         #region Operators
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3 which holds the result of the multiplication</returns>
         public static Matrix3 operator *(Matrix3x4 left, Matrix4x3 right)
         {
             return Matrix3x4.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4 which holds the result of the multiplication</returns>
         public static Matrix3x4 operator *(Matrix3x4 left, Matrix3x4 right)
         {
             return Matrix3x4.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4 which holds the result of the multiplication</returns>
         public static Matrix3x4 operator *(Matrix3x4 left, float right)
         {
             return Matrix3x4.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4 which holds the result of the addition</returns>
         public static Matrix3x4 operator +(Matrix3x4 left, Matrix3x4 right)
         {
             return Matrix3x4.Add(left, right);
         }
 
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4 which holds the result of the subtraction</returns>
         public static Matrix3x4 operator -(Matrix3x4 left, Matrix3x4 right)
         {
             return Matrix3x4.Subtract(left, right);
         }
 
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left equals right; false otherwise.</returns>
         public static bool operator ==(Matrix3x4 left, Matrix3x4 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left does not equal right; false otherwise.</returns>
         public static bool operator !=(Matrix3x4 left, Matrix3x4 right)
         {
             return !left.Equals(right);
@@ -798,6 +935,10 @@ namespace OpenTK
 
         #region public override string ToString()
 
+        /// <summary>
+        /// Returns a System.String that represents the current Matrix4.
+        /// </summary>
+        /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
             return string.Format("{0}\n{1}\n{2}", Row0, Row1, Row2);
@@ -807,6 +948,10 @@ namespace OpenTK
 
         #region public override int GetHashCode()
 
+        /// <summary>
+        /// Returns the hashcode for this instance.
+        /// </summary>
+        /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
             return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
@@ -816,6 +961,11 @@ namespace OpenTK
 
         #region public override bool Equals(object obj)
 
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>True if the instances are equal; false otherwise.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x4))

--- a/Source/OpenTK/Math/Matrix3x4d.cs
+++ b/Source/OpenTK/Math/Matrix3x4d.cs
@@ -196,6 +196,28 @@ namespace OpenTK
         /// </summary>
         public double M34 { get { return Row2.W; } set { Row2.W = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3d Diagonal
+        {
+            get
+            {
+                return new Vector3d(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
+
         #endregion
 
         #region Indexers
@@ -227,6 +249,9 @@ namespace OpenTK
 
         #region public void Invert()
 
+        /// <summary>
+        /// Converts this instance into its inverse.
+        /// </summary>
         public void Invert()
         {
             this = Matrix3x4d.Invert(this);
@@ -620,6 +645,12 @@ namespace OpenTK
             result.Row2.Z = (lM31 * rM13) + (lM32 * rM23) + (lM33 * rM33) + (lM34 * rM43);
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix3x4d Mult(Matrix3x4d left, Matrix3x4d right)
         {
             Matrix3x4d result;
@@ -627,6 +658,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
         {
             double lM11 = left.Row0.X, lM12 = left.Row0.Y, lM13 = left.Row0.Z, lM14 = left.Row0.W,
@@ -659,6 +696,12 @@ namespace OpenTK
             result.Row2.W += lM34;*/
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix3x4d Mult(Matrix3x4d left, double right)
         {
             Matrix3x4d result;
@@ -666,6 +709,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix3x4d left, double right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 * right;
@@ -677,6 +726,12 @@ namespace OpenTK
 
         #region Add Functions
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
         public static Matrix3x4d Add(Matrix3x4d left, Matrix3x4d right)
         {
             Matrix3x4d result;
@@ -684,6 +739,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
         public static void Add(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 + right.Row0;
@@ -695,6 +756,12 @@ namespace OpenTK
 
         #region Subtract Functions
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
         public static Matrix3x4d Subtract(Matrix3x4d left, Matrix3x4d right)
         {
             Matrix3x4d result;
@@ -702,6 +769,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
         public static void Subtract(ref Matrix3x4d left, ref Matrix3x4d right, out Matrix3x4d result)
         {
             result.Row0 = left.Row0 - right.Row0;
@@ -713,6 +786,12 @@ namespace OpenTK
 
         #region Invert Functions
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static Matrix3x4d Invert(Matrix3x4d mat)
         {
             Matrix3x4d result;
@@ -720,6 +799,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(ref Matrix3x4d mat, out Matrix3x4d result)
         {
             Matrix3d inverseRotation = new Matrix3d(mat.Column0, mat.Column1, mat.Column2);
@@ -738,11 +823,21 @@ namespace OpenTK
 
         #region Transpose
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <returns>The transpose of the given matrix</returns>
         public static Matrix4x3d Transpose(Matrix3x4d mat)
         {
             return new Matrix4x3d(mat.Column0, mat.Column1, mat.Column2, mat.Column3);
         }
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <param name="result">The result of the calculation</param>
         public static void Transpose(ref Matrix3x4d mat, out Matrix4x3d result)
         {
             result.Row0 = mat.Column0;
@@ -757,36 +852,78 @@ namespace OpenTK
 
         #region Operators
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3d which holds the result of the multiplication</returns>
         public static Matrix3d operator *(Matrix3x4d left, Matrix4x3d right)
         {
             return Matrix3x4d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4d which holds the result of the multiplication</returns>
         public static Matrix3x4d operator *(Matrix3x4d left, Matrix3x4d right)
         {
             return Matrix3x4d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4d which holds the result of the multiplication</returns>
         public static Matrix3x4d operator *(Matrix3x4d left, double right)
         {
             return Matrix3x4d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4d which holds the result of the addition</returns>
         public static Matrix3x4d operator +(Matrix3x4d left, Matrix3x4d right)
         {
             return Matrix3x4d.Add(left, right);
         }
 
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix3x4d which holds the result of the subtraction</returns>
         public static Matrix3x4d operator -(Matrix3x4d left, Matrix3x4d right)
         {
             return Matrix3x4d.Subtract(left, right);
         }
 
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left equals right; false otherwise.</returns>
         public static bool operator ==(Matrix3x4d left, Matrix3x4d right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left does not equal right; false otherwise.</returns>
         public static bool operator !=(Matrix3x4d left, Matrix3x4d right)
         {
             return !left.Equals(right);
@@ -798,6 +935,10 @@ namespace OpenTK
 
         #region public override string ToString()
 
+        /// <summary>
+        /// Returns a System.String that represents the current Matrix4.
+        /// </summary>
+        /// <returns>The string representation of the matrix.</returns>
         public override string ToString()
         {
             return string.Format("{0}\n{1}\n{2}", Row0, Row1, Row2);
@@ -807,6 +948,10 @@ namespace OpenTK
 
         #region public override int GetHashCode()
 
+        /// <summary>
+        /// Returns the hashcode for this instance.
+        /// </summary>
+        /// <returns>A System.Int32 containing the unique hashcode for this instance.</returns>
         public override int GetHashCode()
         {
             return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
@@ -816,6 +961,11 @@ namespace OpenTK
 
         #region public override bool Equals(object obj)
 
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>True if the instances are equal; false otherwise.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is Matrix3x4d))

--- a/Source/OpenTK/Math/Matrix4.cs
+++ b/Source/OpenTK/Math/Matrix4.cs
@@ -261,6 +261,29 @@ namespace OpenTK
         /// </summary>
         public float M44 { get { return Row3.W; } set { Row3.W = value; } }
         
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector4 Diagonal
+        {
+            get
+            {
+                return new Vector4(Row0.X, Row1.Y, Row2.Z, Row3.W);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+                Row3.W = value.W;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y + Row2.Z + Row3.W; } }
+
         #endregion
 
         #region Indexers
@@ -1266,6 +1289,68 @@ namespace OpenTK
 
         #endregion
 
+        #region Add Functions
+
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
+        public static Matrix4 Add(Matrix4 left, Matrix4 right)
+        {
+            Matrix4 result;
+            Add(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
+        public static void Add(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
+        {
+            result.Row0 = left.Row0 + right.Row0;
+            result.Row1 = left.Row1 + right.Row1;
+            result.Row2 = left.Row2 + right.Row2;
+            result.Row3 = left.Row3 + right.Row3;
+        }
+
+        #endregion
+
+        #region Subtract Functions
+
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
+        public static Matrix4 Subtract(Matrix4 left, Matrix4 right)
+        {
+            Matrix4 result;
+            Subtract(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
+        public static void Subtract(ref Matrix4 left, ref Matrix4 right, out Matrix4 result)
+        {
+            result.Row0 = left.Row0 - right.Row0;
+            result.Row1 = left.Row1 - right.Row1;
+            result.Row2 = left.Row2 - right.Row2;
+            result.Row3 = left.Row3 - right.Row3;
+        }
+
+        #endregion
+
         #region Multiply Functions
 
         /// <summary>
@@ -1314,6 +1399,33 @@ namespace OpenTK
             result.Row3.Y = (((lM41 * rM12) + (lM42 * rM22)) + (lM43 * rM32)) + (lM44 * rM42);
             result.Row3.Z = (((lM41 * rM13) + (lM42 * rM23)) + (lM43 * rM33)) + (lM44 * rM43);
             result.Row3.W = (((lM41 * rM14) + (lM42 * rM24)) + (lM43 * rM34)) + (lM44 * rM44);
+        }
+
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
+        public static Matrix4 Mult(Matrix4 left, float right)
+        {
+            Matrix4 result;
+            Mult(ref left, right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
+        public static void Mult(ref Matrix4 left, float right, out Matrix4 result)
+        {
+            result.Row0 = left.Row0 * right;
+            result.Row1 = left.Row1 * right;
+            result.Row2 = left.Row2 * right;
+            result.Row3 = left.Row3 * right;
         }
 
         #endregion
@@ -1497,6 +1609,39 @@ namespace OpenTK
         public static Matrix4 operator *(Matrix4 left, Matrix4 right)
         {
             return Matrix4.Mult(left, right);
+        }
+
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4 which holds the result of the multiplication</returns>
+        public static Matrix4 operator *(Matrix4 left, float right)
+        {
+            return Matrix4.Mult(left, right);
+        }
+
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4 which holds the result of the addition</returns>
+        public static Matrix4 operator +(Matrix4 left, Matrix4 right)
+        {
+            return Matrix4.Add(left, right);
+        }
+
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4 which holds the result of the subtraction</returns>
+        public static Matrix4 operator -(Matrix4 left, Matrix4 right)
+        {
+            return Matrix4.Subtract(left, right);
         }
 
         /// <summary>

--- a/Source/OpenTK/Math/Matrix4d.cs
+++ b/Source/OpenTK/Math/Matrix4d.cs
@@ -248,6 +248,29 @@ namespace OpenTK
         /// </summary>
         public double M44 { get { return Row3.W; } set { Row3.W = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector4d Diagonal
+        {
+            get
+            {
+                return new Vector4d(Row0.X, Row1.Y, Row2.Z, Row3.W);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+                Row3.W = value.W;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y + Row2.Z + Row3.W; } }
+
         #endregion
 
         #region Indexers
@@ -862,8 +885,6 @@ namespace OpenTK
 
         #endregion
 
-
-        
         #region CreateFromQuaternion
         /// <summary>
         /// Build a rotation matrix from the specified quaternion.
@@ -937,7 +958,6 @@ namespace OpenTK
         }
         
         #endregion
-
 
         #region Obsolete Functions
 
@@ -1191,6 +1211,68 @@ namespace OpenTK
 
         #endregion
 
+        #region Add Functions
+
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
+        public static Matrix4d Add(Matrix4d left, Matrix4d right)
+        {
+            Matrix4d result;
+            Add(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
+        public static void Add(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
+        {
+            result.Row0 = left.Row0 + right.Row0;
+            result.Row1 = left.Row1 + right.Row1;
+            result.Row2 = left.Row2 + right.Row2;
+            result.Row3 = left.Row3 + right.Row3;
+        }
+
+        #endregion
+
+        #region Subtract Functions
+
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
+        public static Matrix4d Subtract(Matrix4d left, Matrix4d right)
+        {
+            Matrix4d result;
+            Subtract(ref left, ref right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
+        public static void Subtract(ref Matrix4d left, ref Matrix4d right, out Matrix4d result)
+        {
+            result.Row0 = left.Row0 - right.Row0;
+            result.Row1 = left.Row1 - right.Row1;
+            result.Row2 = left.Row2 - right.Row2;
+            result.Row3 = left.Row3 - right.Row3;
+        }
+
+        #endregion
+
         #region Multiply Functions
 
         /// <summary>
@@ -1239,6 +1321,33 @@ namespace OpenTK
             result.Row3.Y = (((lM41 * rM12) + (lM42 * rM22)) + (lM43 * rM32)) + (lM44 * rM42);
             result.Row3.Z = (((lM41 * rM13) + (lM42 * rM23)) + (lM43 * rM33)) + (lM44 * rM43);
             result.Row3.W = (((lM41 * rM14) + (lM42 * rM24)) + (lM43 * rM34)) + (lM44 * rM44);
+        }
+
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
+        public static Matrix4d Mult(Matrix4d left, double right)
+        {
+            Matrix4d result;
+            Mult(ref left, right, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
+        public static void Mult(ref Matrix4d left, double right, out Matrix4d result)
+        {
+            result.Row0 = left.Row0 * right;
+            result.Row1 = left.Row1 * right;
+            result.Row2 = left.Row2 * right;
+            result.Row3 = left.Row3 * right;
         }
 
         #endregion
@@ -1398,6 +1507,39 @@ namespace OpenTK
         public static Matrix4d operator *(Matrix4d left, Matrix4d right)
         {
             return Matrix4d.Mult(left, right);
+        }
+
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4d which holds the result of the multiplication</returns>
+        public static Matrix4d operator *(Matrix4d left, float right)
+        {
+            return Matrix4d.Mult(left, right);
+        }
+
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4d which holds the result of the addition</returns>
+        public static Matrix4d operator +(Matrix4d left, Matrix4d right)
+        {
+            return Matrix4d.Add(left, right);
+        }
+
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4d which holds the result of the subtraction</returns>
+        public static Matrix4d operator -(Matrix4d left, Matrix4d right)
+        {
+            return Matrix4d.Subtract(left, right);
         }
 
         /// <summary>

--- a/Source/OpenTK/Math/Matrix4x2.cs
+++ b/Source/OpenTK/Math/Matrix4x2.cs
@@ -166,6 +166,27 @@ namespace OpenTK
         /// </summary>
         public float M42 { get { return Row3.Y; } set { Row3.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2 Diagonal
+        {
+            get
+            {
+                return new Vector2(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix4x2d.cs
+++ b/Source/OpenTK/Math/Matrix4x2d.cs
@@ -166,6 +166,27 @@ namespace OpenTK
         /// </summary>
         public double M42 { get { return Row3.Y; } set { Row3.Y = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector2d Diagonal
+        {
+            get
+            {
+                return new Vector2d(Row0.X, Row1.Y);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y; } }
+
         #endregion
 
         #region Indexers

--- a/Source/OpenTK/Math/Matrix4x3.cs
+++ b/Source/OpenTK/Math/Matrix4x3.cs
@@ -197,6 +197,28 @@ namespace OpenTK
         /// </summary>
         public float M43 { get { return Row3.Z; } set { Row3.Z = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3 Diagonal
+        {
+            get
+            {
+                return new Vector3(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public float Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
+
         #endregion
 
         #region Indexers
@@ -635,6 +657,12 @@ namespace OpenTK
             result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34);
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix4x3 Mult(Matrix4x3 left, Matrix4x3 right)
         {
             Matrix4x3 result;
@@ -674,6 +702,12 @@ namespace OpenTK
             result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + rM43;
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix4x3 Mult(Matrix4x3 left, float right)
         {
             Matrix4x3 result;
@@ -681,7 +715,12 @@ namespace OpenTK
             return result;
         }
 
-
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix4x3 left, float right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 * right;
@@ -694,6 +733,12 @@ namespace OpenTK
 
         #region Add Functions
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
         public static Matrix4x3 Add(Matrix4x3 left, Matrix4x3 right)
         {
             Matrix4x3 result;
@@ -701,6 +746,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
         public static void Add(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 + right.Row0;
@@ -713,6 +764,12 @@ namespace OpenTK
 
         #region Subtract Functions
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
         public static Matrix4x3 Subtract(Matrix4x3 left, Matrix4x3 right)
         {
             Matrix4x3 result;
@@ -720,6 +777,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
         public static void Subtract(ref Matrix4x3 left, ref Matrix4x3 right, out Matrix4x3 result)
         {
             result.Row0 = left.Row0 - right.Row0;
@@ -732,6 +795,12 @@ namespace OpenTK
 
         #region Invert Functions
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static Matrix4x3 Invert(Matrix4x3 mat)
         {
             Matrix4x3 result;
@@ -739,6 +808,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(ref Matrix4x3 mat, out Matrix4x3 result)
         {
             Matrix3 inverseRotation = new Matrix3(mat.Column0.Xyz, mat.Column1.Xyz, mat.Column2.Xyz);
@@ -757,12 +832,21 @@ namespace OpenTK
         #endregion
 
         #region Transpose
-
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <returns>The transpose of the given matrix</returns>
         public static Matrix3x4 Transpose(Matrix4x3 mat)
         {
             return new Matrix3x4(mat.Column0, mat.Column1, mat.Column2);
         }
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <param name="result">The result of the calculation</param>
         public static void Transpose(ref Matrix4x3 mat, out Matrix3x4 result)
         {
             result.Row0 = mat.Column0;
@@ -776,36 +860,78 @@ namespace OpenTK
 
         #region Operators
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4 which holds the result of the multiplication</returns>
         public static Matrix4 operator *(Matrix4x3 left, Matrix3x4 right)
         {
             return Matrix4x3.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3 which holds the result of the multiplication</returns>
         public static Matrix4x3 operator *(Matrix4x3 left, Matrix4x3 right)
         {
             return Matrix4x3.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3 which holds the result of the multiplication</returns>
         public static Matrix4x3 operator *(Matrix4x3 left, float right)
         {
             return Matrix4x3.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3 which holds the result of the addition</returns>
         public static Matrix4x3 operator +(Matrix4x3 left, Matrix4x3 right)
         {
             return Matrix4x3.Add(left, right);
         }
 
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3 which holds the result of the subtraction</returns>
         public static Matrix4x3 operator -(Matrix4x3 left, Matrix4x3 right)
         {
             return Matrix4x3.Subtract(left, right);
         }
 
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left equals right; false otherwise.</returns>
         public static bool operator ==(Matrix4x3 left, Matrix4x3 right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left does not equal right; false otherwise.</returns>
         public static bool operator !=(Matrix4x3 left, Matrix4x3 right)
         {
             return !left.Equals(right);

--- a/Source/OpenTK/Math/Matrix4x3d.cs
+++ b/Source/OpenTK/Math/Matrix4x3d.cs
@@ -197,6 +197,28 @@ namespace OpenTK
         /// </summary>
         public double M43 { get { return Row3.Z; } set { Row3.Z = value; } }
 
+        /// <summary>
+        /// Gets or sets the values along the main diagonal of the matrix.
+        /// </summary>
+        public Vector3d Diagonal
+        {
+            get
+            {
+                return new Vector3d(Row0.X, Row1.Y, Row2.Z);
+            }
+            set
+            {
+                Row0.X = value.X;
+                Row1.Y = value.Y;
+                Row2.Z = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace of the matrix, the sum of the values along the diagonal.
+        /// </summary>
+        public double Trace { get { return Row0.X + Row1.Y + Row2.Z; } }
+
         #endregion
 
         #region Indexers
@@ -230,6 +252,9 @@ namespace OpenTK
 
         #region public void Invert()
 
+        /// <summary>
+        /// Converts this instance into its inverse.
+        /// </summary>
         public void Invert()
         {
             this = Matrix4x3d.Invert(this);
@@ -632,6 +657,12 @@ namespace OpenTK
             result.Row3.W = (lM41 * rM14) + (lM42 * rM24) + (lM43 * rM34);
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix4x3d Mult(Matrix4x3d left, Matrix4x3d right)
         {
             Matrix4x3d result;
@@ -639,6 +670,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
         {
             double lM11 = left.Row0.X, lM12 = left.Row0.Y, lM13 = left.Row0.Z,
@@ -664,6 +701,12 @@ namespace OpenTK
             result.Row3.Z = (lM41 * rM13) + (lM42 * rM23) + (lM43 * rM33) + rM43;
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <returns>A new instance that is the result of the multiplication</returns>
         public static Matrix4x3d Mult(Matrix4x3d left, double right)
         {
             Matrix4x3d result;
@@ -671,6 +714,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Multiplies an instance by a scalar.
+        /// </summary>
+        /// <param name="left">The left operand of the multiplication.</param>
+        /// <param name="right">The right operand of the multiplication.</param>
+        /// <param name="result">A new instance that is the result of the multiplication</param>
         public static void Mult(ref Matrix4x3d left, double right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 * right;
@@ -683,6 +732,12 @@ namespace OpenTK
 
         #region Add Functions
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <returns>A new instance that is the result of the addition.</returns>
         public static Matrix4x3d Add(Matrix4x3d left, Matrix4x3d right)
         {
             Matrix4x3d result;
@@ -690,6 +745,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Adds two instances.
+        /// </summary>
+        /// <param name="left">The left operand of the addition.</param>
+        /// <param name="right">The right operand of the addition.</param>
+        /// <param name="result">A new instance that is the result of the addition.</param>
         public static void Add(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 + right.Row0;
@@ -702,6 +763,12 @@ namespace OpenTK
 
         #region Subtract Functions
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <returns>A new instance that is the result of the subraction.</returns>
         public static Matrix4x3d Subtract(Matrix4x3d left, Matrix4x3d right)
         {
             Matrix4x3d result;
@@ -709,6 +776,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Subtracts one instance from another.
+        /// </summary>
+        /// <param name="left">The left operand of the subraction.</param>
+        /// <param name="right">The right operand of the subraction.</param>
+        /// <param name="result">A new instance that is the result of the subraction.</param>
         public static void Subtract(ref Matrix4x3d left, ref Matrix4x3d right, out Matrix4x3d result)
         {
             result.Row0 = left.Row0 - right.Row0;
@@ -721,6 +794,12 @@ namespace OpenTK
 
         #region Invert Functions
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <returns>The inverse of the given matrix if it has one, or the input if it is singular</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static Matrix4x3d Invert(Matrix4x3d mat)
         {
             Matrix4x3d result;
@@ -728,6 +807,12 @@ namespace OpenTK
             return result;
         }
 
+        /// <summary>
+        /// Calculate the inverse of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to invert</param>
+        /// <param name="result">The inverse of the given matrix if it has one, or the input if it is singular</param>
+        /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(ref Matrix4x3d mat, out Matrix4x3d result)
         {
             Matrix3d inverseRotation = new Matrix3d(mat.Column0.Xyz, mat.Column1.Xyz, mat.Column2.Xyz);
@@ -747,11 +832,21 @@ namespace OpenTK
 
         #region Transpose
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <returns>The transpose of the given matrix</returns>
         public static Matrix3x4d Transpose(Matrix4x3d mat)
         {
             return new Matrix3x4d(mat.Column0, mat.Column1, mat.Column2);
         }
 
+        /// <summary>
+        /// Calculate the transpose of the given matrix
+        /// </summary>
+        /// <param name="mat">The matrix to transpose</param>
+        /// <param name="result">The result of the calculation</param>
         public static void Transpose(ref Matrix4x3d mat, out Matrix3x4d result)
         {
             result.Row0 = mat.Column0;
@@ -765,36 +860,78 @@ namespace OpenTK
 
         #region Operators
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4d which holds the result of the multiplication</returns>
         public static Matrix4d operator *(Matrix4x3d left, Matrix3x4d right)
         {
             return Matrix4x3d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3d which holds the result of the multiplication</returns>
         public static Matrix4x3d operator *(Matrix4x3d left, Matrix4x3d right)
         {
             return Matrix4x3d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix-scalar multiplication
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3d which holds the result of the multiplication</returns>
         public static Matrix4x3d operator *(Matrix4x3d left, double right)
         {
             return Matrix4x3d.Mult(left, right);
         }
 
+        /// <summary>
+        /// Matrix addition
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3d which holds the result of the addition</returns>
         public static Matrix4x3d operator +(Matrix4x3d left, Matrix4x3d right)
         {
             return Matrix4x3d.Add(left, right);
         }
 
+        /// <summary>
+        /// Matrix subtraction
+        /// </summary>
+        /// <param name="left">left-hand operand</param>
+        /// <param name="right">right-hand operand</param>
+        /// <returns>A new Matrix4x3d which holds the result of the subtraction</returns>
         public static Matrix4x3d operator -(Matrix4x3d left, Matrix4x3d right)
         {
             return Matrix4x3d.Subtract(left, right);
         }
 
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left equals right; false otherwise.</returns>
         public static bool operator ==(Matrix4x3d left, Matrix4x3d right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns>True, if left does not equal right; false otherwise.</returns>
         public static bool operator !=(Matrix4x3d left, Matrix4x3d right)
         {
             return !left.Equals(right);

--- a/Source/OpenTK/Math/Quaternion.cs
+++ b/Source/OpenTK/Math/Quaternion.cs
@@ -252,7 +252,7 @@ namespace OpenTK
         /// <summary>
         /// Defines the identity quaternion.
         /// </summary>
-        public static Quaternion Identity = new Quaternion(0, 0, 0, 1);
+        public static readonly Quaternion Identity = new Quaternion(0, 0, 0, 1);
 
         #endregion
 
@@ -507,6 +507,8 @@ namespace OpenTK
 
         #endregion
 
+        #region FromMatrix
+
         /// <summary>
         /// Builds a quaternion from the given rotation matrix
         /// </summary>
@@ -574,6 +576,8 @@ namespace OpenTK
                 }
             }
         }
+
+        #endregion
 
         #region Slerp
 

--- a/Source/OpenTK/Math/Quaternion.cs
+++ b/Source/OpenTK/Math/Quaternion.cs
@@ -489,7 +489,7 @@ namespace OpenTK
         /// </summary>
         /// <param name="axis">The axis to rotate about</param>
         /// <param name="angle">The rotation angle in radians</param>
-        /// <returns></returns>
+        /// <returns>The equivalent quaternion</returns>
         public static Quaternion FromAxisAngle(Vector3 axis, float angle)
         {
             if (axis.LengthSquared == 0.0f)
@@ -506,6 +506,74 @@ namespace OpenTK
         }
 
         #endregion
+
+        /// <summary>
+        /// Builds a quaternion from the given rotation matrix
+        /// </summary>
+        /// <param name="matrix">A rotation matrix</param>
+        /// <returns>The equivalent quaternion</returns>
+        public static Quaternion FromMatrix(Matrix3 matrix)
+        {
+            Quaternion result;
+            FromMatrix(ref matrix, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Builds a quaternion from the given rotation matrix
+        /// </summary>
+        /// <param name="matrix">A rotation matrix</param>
+        /// <param name="result">The equivalent quaternion</param>
+        public static void FromMatrix(ref Matrix3 matrix, out Quaternion result)
+        {
+            float trace = matrix.Trace;
+
+            if (trace > 0)
+            {
+                float s = (float)Math.Sqrt(trace + 1) * 2;
+                float invS = 1f / s;
+
+                result.w = s * 0.25f;
+                result.xyz.X = (matrix.Row2.Y - matrix.Row1.Z) * invS;
+                result.xyz.Y = (matrix.Row0.Z - matrix.Row2.X) * invS;
+                result.xyz.Z = (matrix.Row1.X - matrix.Row0.Y) * invS;
+            }
+            else
+            {
+                float m00 = matrix.Row0.X, m11 = matrix.Row1.Y, m22 = matrix.Row2.Z;
+
+                if (m00 > m11 && m00 > m22)
+                {
+                    float s = (float)Math.Sqrt(1 + m00 - m11 - m22) * 2;
+                    float invS = 1f / s;
+
+                    result.w = (matrix.Row2.Y - matrix.Row1.Z) * invS;
+                    result.xyz.X = s * 0.25f;
+                    result.xyz.Y = (matrix.Row0.Y + matrix.Row1.X) * invS;
+                    result.xyz.Z = (matrix.Row0.Z + matrix.Row2.X) * invS;
+                }
+                else if (m11 > m22)
+                {
+                    float s = (float)Math.Sqrt(1 + m11 - m00 - m22) * 2;
+                    float invS = 1f / s;
+
+                    result.w = (matrix.Row0.Z - matrix.Row2.X) * invS;
+                    result.xyz.X = (matrix.Row0.Y + matrix.Row1.X) * invS;
+                    result.xyz.Y = s * 0.25f;
+                    result.xyz.Z = (matrix.Row1.Z + matrix.Row2.Y) * invS;
+                }
+                else
+                {
+                    float s = (float)Math.Sqrt(1 + m22 - m00 - m11) * 2;
+                    float invS = 1f / s;
+
+                    result.w = (matrix.Row1.X - matrix.Row0.Y) * invS;
+                    result.xyz.X = (matrix.Row0.Z + matrix.Row2.X) * invS;
+                    result.xyz.Y = (matrix.Row1.Z + matrix.Row2.Y) * invS;
+                    result.xyz.Z = s * 0.25f;
+                }
+            }
+        }
 
         #region Slerp
 

--- a/Source/OpenTK/Math/Quaterniond.cs
+++ b/Source/OpenTK/Math/Quaterniond.cs
@@ -507,6 +507,78 @@ namespace OpenTK
 
         #endregion
 
+        #region FromMatrix
+
+        /// <summary>
+        /// Builds a quaternion from the given rotation matrix
+        /// </summary>
+        /// <param name="matrix">A rotation matrix</param>
+        /// <returns>The equivalent quaternion</returns>
+        public static Quaterniond FromMatrix(Matrix3d matrix)
+        {
+            Quaterniond result;
+            FromMatrix(ref matrix, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Builds a quaternion from the given rotation matrix
+        /// </summary>
+        /// <param name="matrix">A rotation matrix</param>
+        /// <param name="result">The equivalent quaternion</param>
+        public static void FromMatrix(ref Matrix3d matrix, out Quaterniond result)
+        {
+            double trace = matrix.Trace;
+
+            if (trace > 0)
+            {
+                double s = Math.Sqrt(trace + 1) * 2;
+                double invS = 1.0 / s;
+
+                result.w = s * 0.25;
+                result.xyz.X = (matrix.Row2.Y - matrix.Row1.Z) * invS;
+                result.xyz.Y = (matrix.Row0.Z - matrix.Row2.X) * invS;
+                result.xyz.Z = (matrix.Row1.X - matrix.Row0.Y) * invS;
+            }
+            else
+            {
+                double m00 = matrix.Row0.X, m11 = matrix.Row1.Y, m22 = matrix.Row2.Z;
+
+                if (m00 > m11 && m00 > m22)
+                {
+                    double s = Math.Sqrt(1 + m00 - m11 - m22) * 2;
+                    double invS = 1.0 / s;
+
+                    result.w = (matrix.Row2.Y - matrix.Row1.Z) * invS;
+                    result.xyz.X = s * 0.25;
+                    result.xyz.Y = (matrix.Row0.Y + matrix.Row1.X) * invS;
+                    result.xyz.Z = (matrix.Row0.Z + matrix.Row2.X) * invS;
+                }
+                else if (m11 > m22)
+                {
+                    double s = Math.Sqrt(1 + m11 - m00 - m22) * 2;
+                    double invS = 1.0 / s;
+
+                    result.w = (matrix.Row0.Z - matrix.Row2.X) * invS;
+                    result.xyz.X = (matrix.Row0.Y + matrix.Row1.X) * invS;
+                    result.xyz.Y = s * 0.25;
+                    result.xyz.Z = (matrix.Row1.Z + matrix.Row2.Y) * invS;
+                }
+                else
+                {
+                    double s = Math.Sqrt(1 + m22 - m00 - m11) * 2;
+                    double invS = 1.0 / s;
+
+                    result.w = (matrix.Row1.X - matrix.Row0.Y) * invS;
+                    result.xyz.X = (matrix.Row0.Z + matrix.Row2.X) * invS;
+                    result.xyz.Y = (matrix.Row1.Z + matrix.Row2.Y) * invS;
+                    result.xyz.Z = s * 0.25;
+                }
+            }
+        }
+
+        #endregion
+
         #region Slerp
 
         /// <summary>


### PR DESCRIPTION
I needed a matrix-to-quaternion conversion for parsing a model format, so I implemented it here.

The APIs I added:
- `Quaternion(d).FromMatrix()`
- `Matrix[2/3/4/2x3/2x4/3x2/3x4/4x2/4x3](d).Diagonal`
- `Matrix[2/3/4/2x3/2x4/3x2/3x4/4x2/4x3](d).Trace`

Also I added a bunch of missing doc comments to significantly reduce the number of compiler warnings.
