### PR TITLE
Fix for setting Matrix/Vector values by Index

### DIFF
--- a/Source/OpenTK/Math/Matrix2.cs
+++ b/Source/OpenTK/Math/Matrix2.cs
@@ -182,7 +182,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix2d.cs
+++ b/Source/OpenTK/Math/Matrix2d.cs
@@ -182,7 +182,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix2x3.cs
+++ b/Source/OpenTK/Math/Matrix2x3.cs
@@ -184,7 +184,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix2x3d.cs
+++ b/Source/OpenTK/Math/Matrix2x3d.cs
@@ -184,7 +184,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix2x4.cs
+++ b/Source/OpenTK/Math/Matrix2x4.cs
@@ -205,7 +205,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix2x4d.cs
+++ b/Source/OpenTK/Math/Matrix2x4d.cs
@@ -205,7 +205,7 @@ namespace OpenTK
             {
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3.cs
+++ b/Source/OpenTK/Math/Matrix3.cs
@@ -245,7 +245,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3d.cs
+++ b/Source/OpenTK/Math/Matrix3d.cs
@@ -241,7 +241,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3x2.cs
+++ b/Source/OpenTK/Math/Matrix3x2.cs
@@ -186,7 +186,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3x2d.cs
+++ b/Source/OpenTK/Math/Matrix3x2d.cs
@@ -186,7 +186,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3x4.cs
+++ b/Source/OpenTK/Math/Matrix3x4.cs
@@ -239,7 +239,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix3x4d.cs
+++ b/Source/OpenTK/Math/Matrix3x4d.cs
@@ -239,7 +239,7 @@ namespace OpenTK
                 if (rowIndex == 0) Row0[columnIndex] = value;
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4.cs
+++ b/Source/OpenTK/Math/Matrix4.cs
@@ -307,7 +307,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4d.cs
+++ b/Source/OpenTK/Math/Matrix4d.cs
@@ -294,7 +294,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4x2.cs
+++ b/Source/OpenTK/Math/Matrix4x2.cs
@@ -210,7 +210,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4x2d.cs
+++ b/Source/OpenTK/Math/Matrix4x2d.cs
@@ -210,7 +210,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4x3.cs
+++ b/Source/OpenTK/Math/Matrix4x3.cs
@@ -242,7 +242,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Matrix4x3d.cs
+++ b/Source/OpenTK/Math/Matrix4x3d.cs
@@ -242,7 +242,7 @@ namespace OpenTK
                 else if (rowIndex == 1) Row1[columnIndex] = value;
                 else if (rowIndex == 2) Row2[columnIndex] = value;
                 else if (rowIndex == 3) Row3[columnIndex] = value;
-                throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
+                else throw new IndexOutOfRangeException("You tried to set this matrix at: (" + rowIndex + ", " + columnIndex + ")");
             }
         }
 

--- a/Source/OpenTK/Math/Vector2.cs
+++ b/Source/OpenTK/Math/Vector2.cs
@@ -121,7 +121,7 @@ namespace OpenTK
             } set{
                 if(index == 0) X = value;
                 else if(index == 1) Y = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 

--- a/Source/OpenTK/Math/Vector2d.cs
+++ b/Source/OpenTK/Math/Vector2d.cs
@@ -104,7 +104,7 @@ namespace OpenTK
             } set{
                 if(index == 0) X = value;
                 else if(index == 1) Y = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 

--- a/Source/OpenTK/Math/Vector3.cs
+++ b/Source/OpenTK/Math/Vector3.cs
@@ -133,7 +133,7 @@ namespace OpenTK
                 if(index == 0) X = value;
                 else if(index == 1) Y = value;
                 else if(index == 2) Z = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 

--- a/Source/OpenTK/Math/Vector3d.cs
+++ b/Source/OpenTK/Math/Vector3d.cs
@@ -131,7 +131,7 @@ namespace OpenTK
                 if(index == 0) X = value;
                 else if(index == 1) Y = value;
                 else if(index == 2) Z = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 

--- a/Source/OpenTK/Math/Vector4.cs
+++ b/Source/OpenTK/Math/Vector4.cs
@@ -193,7 +193,7 @@ namespace OpenTK
                 else if(index == 1) Y = value;
                 else if(index == 2) Z = value;
                 else if(index == 3) W = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 

--- a/Source/OpenTK/Math/Vector4d.cs
+++ b/Source/OpenTK/Math/Vector4d.cs
@@ -191,7 +191,7 @@ namespace OpenTK
                 else if(index == 1) Y = value;
                 else if(index == 2) Z = value;
                 else if(index == 3) W = value;
-                throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
             }
         }
 


### PR DESCRIPTION
Many `Matrix*/Vector*` implementations were throwing `IndexOutOfRangeException` when you tried to set their values via their indexer due to a missing else statement.

example: things like the following would throw exceptions when the index was clearly in bounds.

```
Matrix3 m = new Matrix3();
m[0,0] = 1; // IndexOutOfRangeException
```

I've added the missing else into all Matrix implementations, and select Vector implementations where it was missing.
