### PR TITLE
Replace IndexOutOfRangeException with ArgumentOutOfRangeException in vector indexers

### DIFF
--- a/Source/OpenTK/Math/Vector2.cs
+++ b/Source/OpenTK/Math/Vector2.cs
@@ -110,20 +110,45 @@ namespace OpenTK
 
         #region Public Members
 
+        #region Indexer
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public float this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public float this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 
@@ -299,6 +324,7 @@ namespace OpenTK
             v.Normalize();
             return v;
         }
+
         #region public void Normalize()
 
         /// <summary>

--- a/Source/OpenTK/Math/Vector2d.cs
+++ b/Source/OpenTK/Math/Vector2d.cs
@@ -93,20 +93,45 @@ namespace OpenTK
 
         #region Public Members
 
+        #region Indexer
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public double this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 

--- a/Source/OpenTK/Math/Vector2h.cs
+++ b/Source/OpenTK/Math/Vector2h.cs
@@ -203,6 +203,46 @@ namespace OpenTK
 
         #endregion
 
+        #region Indexer
+
+        /// <summary>
+        /// Gets or sets the value at the index of the Vector.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public Half this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
+            }
+        }
+
+        #endregion
+
         #region Half -> Single
 
         /// <summary>

--- a/Source/OpenTK/Math/Vector3.cs
+++ b/Source/OpenTK/Math/Vector3.cs
@@ -119,23 +119,50 @@ namespace OpenTK
 
         #region Public Members
 
+        #region Indexer
 
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public float this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public float this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 

--- a/Source/OpenTK/Math/Vector3d.cs
+++ b/Source/OpenTK/Math/Vector3d.cs
@@ -118,22 +118,50 @@ namespace OpenTK
 
         #region Public Members
 
+        #region Indexer
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public double this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 

--- a/Source/OpenTK/Math/Vector3h.cs
+++ b/Source/OpenTK/Math/Vector3h.cs
@@ -291,6 +291,51 @@ namespace OpenTK
 
         #endregion
 
+        #region Indexer
+
+        /// <summary>
+        /// Gets or sets the value at the index of the Vector.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public Half this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
+            }
+        }
+
+        #endregion
+
         #region Half -> Single
 
         /// <summary>

--- a/Source/OpenTK/Math/Vector4.cs
+++ b/Source/OpenTK/Math/Vector4.cs
@@ -178,24 +178,55 @@ namespace OpenTK
 
         #region Public Members
 
+        #region Indexer
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public float this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                else if(index == 3) return W;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else if(index == 3) W = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public float this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    case 3:
+                        return W;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    case 3:
+                        W = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 

--- a/Source/OpenTK/Math/Vector4d.cs
+++ b/Source/OpenTK/Math/Vector4d.cs
@@ -175,25 +175,56 @@ namespace OpenTK
         #endregion
 
         #region Public Members
-        
+
+        #region Indexer
+
         /// <summary>
         /// Gets or sets the value at the index of the Vector.
         /// </summary>
-        public double this[int index] {
-            get{
-                if(index == 0) return X;
-                else if(index == 1) return Y;
-                else if(index == 2) return Z;
-                else if(index == 3) return W;
-                throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-            } set{
-                if(index == 0) X = value;
-                else if(index == 1) Y = value;
-                else if(index == 2) Z = value;
-                else if(index == 3) W = value;
-                else throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public double this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    case 3:
+                        return W;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    case 3:
+                        W = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
             }
         }
+
+        #endregion
 
         #region Instance
 

--- a/Source/OpenTK/Math/Vector4h.cs
+++ b/Source/OpenTK/Math/Vector4h.cs
@@ -626,6 +626,56 @@ namespace OpenTK
 
         #endregion
 
+        #region Indexer
+
+        /// <summary>
+        /// Gets or sets the value at the index of the Vector.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <returns>The component of the vector at index.</returns>
+        public Half this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return X;
+                    case 1:
+                        return Y;
+                    case 2:
+                        return Z;
+                    case 3:
+                        return W;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to access this vector at index: " + index);
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    case 3:
+                        W = value;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("You tried to set this vector at index: " + index);
+                }
+            }
+        }
+
+        #endregion
+
         #region Half -> Single
 
         /// <summary>


### PR DESCRIPTION
IndexOutOfRangeException is supposed to only be thrown internally for arrays. Everything else should be throwing ArgumentOutOfRangeExceptions. Even the BCL collections do this.

I copied the Vector3 class out to another project, VS2012's code analysis pointed this out as [CA1065](http://msdn.microsoft.com/en-us/library/bb386039.aspx)
